### PR TITLE
Add support for explicit EOR mode

### DIFF
--- a/libhttpd.c
+++ b/libhttpd.c
@@ -4697,7 +4697,11 @@ httpd_write_sctp( int fd, const char * buf, size_t nbytes,
     cmsg->cmsg_len = CMSG_LEN(sizeof(struct sctp_sndinfo));
     sndinfo = (struct sctp_sndinfo *)CMSG_DATA(cmsg);
     sndinfo->snd_sid = sid;
-    sndinfo->snd_flags = (use_eeor && eor) ? SCTP_EOR : 0;
+    sndinfo->snd_flags = 0;
+#ifdef SCTP_EXPLICIT_EOR
+    if ( use_eeor && eor )
+	sndinfo->snd_flags |= SCTP_EOR;
+#endif
     sndinfo->snd_ppid = htonl(ppid);
     sndinfo->snd_context = 0;
     sndinfo->snd_assoc_id = 0;
@@ -4708,7 +4712,11 @@ httpd_write_sctp( int fd, const char * buf, size_t nbytes,
     cmsg->cmsg_len = CMSG_LEN(sizeof(struct sctp_sndrcvinfo));
     sndrcvinfo = (struct sctp_sndrcvinfo *)CMSG_DATA(cmsg);
     sndrcvinfo->sinfo_stream = sid;
-    sndrcvinfo->sinfo_flags = (use_eeor && eor) ? SCTP_EOR : 0;;
+    sndrcvinfo->sinfo_flags = 0;
+#ifdef SCTP_EXPLICIT_EOR
+    if ( use_eeor && eor )
+	sndrcvinfo->sinfo_flags |= SCTP_EOR;
+#endif
     sndrcvinfo->sinfo_ppid = htonl(ppid);
     sndrcvinfo->sinfo_context = 0;
     sndrcvinfo->sinfo_timetolive = 0;

--- a/libhttpd.c
+++ b/libhttpd.c
@@ -35,6 +35,9 @@
 #define EXPOSED_SERVER_SOFTWARE "thttpd"
 #endif /* SHOW_SERVER_VERSION */
 
+#ifdef FreeBSD
+#define _WITH_DPRINTF
+#endif
 #include <sys/types.h>
 #include <sys/param.h>
 #include <sys/stat.h>

--- a/libhttpd.h
+++ b/libhttpd.h
@@ -157,6 +157,7 @@ typedef struct {
     unsigned int no_i_streams;
     unsigned int no_o_streams;
     size_t send_at_once_limit;
+    int use_eeor;
 #endif
     char* file_address;
     } httpd_conn;

--- a/libhttpd.h
+++ b/libhttpd.h
@@ -297,6 +297,10 @@ ssize_t httpd_read_fully( int fd, void* buf, size_t nbytes );
 
 /* Write the requested buffer completely, accounting for interruptions. */
 ssize_t httpd_write_fully( int fd, const char* buf, size_t nbytes );
+#ifdef USE_SCTP
+ssize_t httpd_write_fully_sctp( int fd, const char* buf, size_t nbytes,
+    int use_eeor, size_t send_at_once_limit );
+#endif
 
 /* Generate debugging statistics syslog message. */
 void httpd_logstats( long secs );

--- a/libhttpd.h
+++ b/libhttpd.h
@@ -298,6 +298,8 @@ ssize_t httpd_read_fully( int fd, void* buf, size_t nbytes );
 /* Write the requested buffer completely, accounting for interruptions. */
 ssize_t httpd_write_fully( int fd, const char* buf, size_t nbytes );
 #ifdef USE_SCTP
+ssize_t httpd_write_sctp( int fd, const char * buf, size_t nbytes,
+    int use_eeor, int eor, uint32_t ppid, uint16_t sid );
 ssize_t httpd_write_fully_sctp( int fd, const char* buf, size_t nbytes,
     int use_eeor, size_t send_at_once_limit );
 #endif

--- a/libhttpd.h
+++ b/libhttpd.h
@@ -301,7 +301,7 @@ ssize_t httpd_write_fully( int fd, const char* buf, size_t nbytes );
 ssize_t httpd_write_sctp( int fd, const char * buf, size_t nbytes,
     int use_eeor, int eor, uint32_t ppid, uint16_t sid );
 ssize_t httpd_write_fully_sctp( int fd, const char* buf, size_t nbytes,
-    int use_eeor, size_t send_at_once_limit );
+    int use_eeor, int eor, size_t send_at_once_limit );
 #endif
 
 /* Generate debugging statistics syslog message. */

--- a/thttpd.c
+++ b/thttpd.c
@@ -1776,7 +1776,7 @@ handle_send( connecttab* c, struct timeval* tvP )
     msg.msg_iovlen = 2;
 #ifdef USE_SCTP
     if ( hc->is_sctp )
-        {
+	{
 	cmsg = (struct cmsghdr *)cmsgbuf;
 	cmsg->cmsg_level = IPPROTO_SCTP;
 #ifdef SCTP_SNDINFO

--- a/thttpd.c
+++ b/thttpd.c
@@ -1784,10 +1784,11 @@ handle_send( connecttab* c, struct timeval* tvP )
 	cmsg->cmsg_len = CMSG_LEN(sizeof(struct sctp_sndinfo));
 	sndinfo = (struct sctp_sndinfo *)CMSG_DATA(cmsg);
 	sndinfo->snd_sid = 0;
-	if (c->end_byte_index - c->next_byte_index > max_bytes)
-	    sndinfo->snd_flags = 0;
-	else
-	    sndinfo->snd_flags = SCTP_EOR;
+	sndinfo->snd_flags = 0;
+#ifdef SCTP_EXPLICIT_EOR
+	if (c->end_byte_index - c->next_byte_index <= max_bytes)
+	    sndinfo->snd_flags |= SCTP_EOR;
+#endif
 	sndinfo->snd_ppid = htonl(0);
 	sndinfo->snd_context = 0;
 	sndinfo->snd_assoc_id = 0;
@@ -1798,10 +1799,11 @@ handle_send( connecttab* c, struct timeval* tvP )
 	cmsg->cmsg_len = CMSG_LEN(sizeof(struct sctp_sndrcvinfo));
 	sndrcvinfo = (struct sctp_sndrcvinfo *)CMSG_DATA(cmsg);
 	sndrcvinfo->sinfo_stream = 0;
-	if (c->end_byte_index - c->next_byte_index > max_bytes)
-	    sndrcvinfo->sinfo_flags = 0;
-	else
-	    sndrcvinfo->sinfo_flags = SCTP_EOR;
+	sndrcvinfo->sinfo_flags = 0;
+#ifdef SCTP_EXPLICIT_EOR
+	if (c->end_byte_index - c->next_byte_index <= max_bytes)
+	    sndrcvinfo->sinfo_flags |= SCTP_EOR;
+#endif
 	sndrcvinfo->sinfo_ppid = htonl(0);
 	sndrcvinfo->sinfo_context = 0;
 	sndrcvinfo->sinfo_timetolive = 0;

--- a/thttpd.c
+++ b/thttpd.c
@@ -1741,7 +1741,18 @@ handle_send( connecttab* c, struct timeval* tvP )
     time_t elapsed;
     httpd_conn* hc = c->hc;
     int tind;
+    struct msghdr msg;
+    struct cmsghdr *cmsg;
     struct iovec iv[2];
+#ifdef USE_SCTP
+#ifdef SCTP_SNDINFO
+    char cmsgbuf[CMSG_SPACE(sizeof(struct sctp_sndinfo))];
+    struct sctp_sndinfo *sndinfo;
+#else
+    char cmsgbuf[CMSG_SPACE(sizeof(struct sctp_sndrcvinfo))];
+    struct sctp_sndrcvinfo *sndrcvinfo;
+#endif
+#endif
 
     if ( c->max_limit == THROTTLE_NOLIMIT )
 	max_bytes = 1000000000L;
@@ -1759,7 +1770,57 @@ handle_send( connecttab* c, struct timeval* tvP )
     iv[0].iov_len = hc->responselen;
     iv[1].iov_base = &(hc->file_address[c->next_byte_index]);
     iv[1].iov_len = MIN( c->end_byte_index - c->next_byte_index, max_bytes );
-    sz = writev( hc->conn_fd, iv, 2 );
+    msg.msg_name = NULL;
+    msg.msg_namelen = 0;
+    msg.msg_iov = iv;
+    msg.msg_iovlen = 2;
+#ifdef USE_SCTP
+    if ( hc->is_sctp )
+        {
+	cmsg = (struct cmsghdr *)cmsgbuf;
+	cmsg->cmsg_level = IPPROTO_SCTP;
+#ifdef SCTP_SNDINFO
+	cmsg->cmsg_type = SCTP_SNDINFO;
+	cmsg->cmsg_len = CMSG_LEN(sizeof(struct sctp_sndinfo));
+	sndinfo = (struct sctp_sndinfo *)CMSG_DATA(cmsg);
+	sndinfo->snd_sid = 0;
+	if (c->end_byte_index - c->next_byte_index > max_bytes)
+	    sndinfo->snd_flags = 0;
+	else
+	    sndinfo->snd_flags = SCTP_EOR;
+	sndinfo->snd_ppid = htonl(0);
+	sndinfo->snd_context = 0;
+	sndinfo->snd_assoc_id = 0;
+	msg.msg_control = cmsg;
+	msg.msg_controllen = CMSG_SPACE(sizeof(struct sctp_sndinfo));
+#else
+	cmsg->cmsg_type = SCTP_SNDRCV;
+	cmsg->cmsg_len = CMSG_LEN(sizeof(struct sctp_sndrcvinfo));
+	sndrcvinfo = (struct sctp_sndrcvinfo *)CMSG_DATA(cmsg);
+	sndrcvinfo->sinfo_stream = 0;
+	if (c->end_byte_index - c->next_byte_index > max_bytes)
+	    sndrcvinfo->sinfo_flags = 0;
+	else
+	    sndrcvinfo->sinfo_flags = SCTP_EOR;
+	sndrcvinfo->sinfo_ppid = htonl(0);
+	sndrcvinfo->sinfo_context = 0;
+	sndrcvinfo->sinfo_timetolive = 0;
+	sndrcvinfo->sinfo_assoc_id = 0;
+	msg.msg_control = cmsg;
+	msg.msg_controllen = CMSG_SPACE(sizeof(struct sctp_sndrcvinfo));
+#endif
+	}
+    else
+	{
+	msg.msg_control = NULL;
+	msg.msg_controllen = 0;
+	}
+#else
+    msg.msg_control = NULL;
+    msg.msg_controllen = 0;
+#endif
+    msg.msg_flags = 0;
+    sz = sendmsg( hc->conn_fd, &msg, 0);
 
     if ( sz < 0 && errno == EINTR )
 	return;

--- a/thttpd.c
+++ b/thttpd.c
@@ -1775,7 +1775,7 @@ handle_send( connecttab* c, struct timeval* tvP )
     msg.msg_iov = iv;
     msg.msg_iovlen = 2;
 #ifdef USE_SCTP
-    if ( hc->is_sctp )
+    if ( hc->is_sctp && hc->use_eeor )
 	{
 	cmsg = (struct cmsghdr *)cmsgbuf;
 	cmsg->cmsg_level = IPPROTO_SCTP;

--- a/thttpd.c
+++ b/thttpd.c
@@ -1820,7 +1820,7 @@ handle_send( connecttab* c, struct timeval* tvP )
     msg.msg_controllen = 0;
 #endif
     msg.msg_flags = 0;
-    sz = sendmsg( hc->conn_fd, &msg, 0);
+    sz = sendmsg( hc->conn_fd, &msg, 0 );
 
     if ( sz < 0 && errno == EINTR )
 	return;

--- a/thttpd.c
+++ b/thttpd.c
@@ -1786,7 +1786,7 @@ handle_send( connecttab* c, struct timeval* tvP )
 	sndinfo->snd_sid = 0;
 	sndinfo->snd_flags = 0;
 #ifdef SCTP_EXPLICIT_EOR
-	if (c->end_byte_index - c->next_byte_index <= max_bytes)
+	if ( c->end_byte_index - c->next_byte_index <= max_bytes )
 	    sndinfo->snd_flags |= SCTP_EOR;
 #endif
 	sndinfo->snd_ppid = htonl(0);
@@ -1801,7 +1801,7 @@ handle_send( connecttab* c, struct timeval* tvP )
 	sndrcvinfo->sinfo_stream = 0;
 	sndrcvinfo->sinfo_flags = 0;
 #ifdef SCTP_EXPLICIT_EOR
-	if (c->end_byte_index - c->next_byte_index <= max_bytes)
+	if ( c->end_byte_index - c->next_byte_index <= max_bytes )
 	    sndrcvinfo->sinfo_flags |= SCTP_EOR;
 #endif
 	sndrcvinfo->sinfo_ppid = htonl(0);


### PR DESCRIPTION
If available, each HTTP response is a single SCTP user-message. This requires support for the explicit EOR mode, which is currently only supported on FreeBSD.
